### PR TITLE
Add `--lib` to `cargo tool cargo-llvm-cov`

### DIFF
--- a/Justfile.jinja
+++ b/Justfile.jinja
@@ -67,7 +67,7 @@ test-all:
     {% if crate_type == "lib" %}cargo just test-doc --all-features{% endif %}
     {% if wasm %}cargo just test-wasm --chrome --headless{% endif %}
 coverage *ARGS:
-    cargo tool cargo-llvm-cov --open
+    cargo tool cargo-llvm-cov --lib --open
 
 coverage-gen:
-    cargo tool cargo-llvm-cov --lcov --output-path lcov.info
+    cargo tool cargo-llvm-cov --lib --lcov --output-path lcov.info


### PR DESCRIPTION
It's rare to cover non-library code, and can cause complications (i.e. more dependencies, including some that aren't always compatible with `cargo tool cargo-llvm-cov`).

See [example](https://github.com/crates-lurey-io/retroglyph/actions/runs/16092207093/job/45410452544):
```txt
error[E0554]: `#![feature]` may not be used on the stable release channel
Error:   --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wayland-backend-0.3.10/src/lib.rs:50:23
   |
50 | #![cfg_attr(coverage, feature(coverage_attribute))]
   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0554`.
```